### PR TITLE
fix: correct error logs when record exists

### DIFF
--- a/pycsw/ogc/csw/csw2.py
+++ b/pycsw/ogc/csw/csw2.py
@@ -1377,7 +1377,7 @@ class Csw2(object):
                         # same identifier, but different source
                         return self.exceptionreport('NoApplicableCode',
                         'source', 'Insert failed: identifier %s in repository\
-                        has source %s.' % (identifier, source))
+                        has source %s.' % (identifier, results[0].source))
 
                     try:
                         self.parent.repository.update(record)

--- a/pycsw/ogc/csw/csw3.py
+++ b/pycsw/ogc/csw/csw3.py
@@ -1440,7 +1440,7 @@ class Csw3(object):
                         # same identifier, but different source
                         return self.exceptionreport('NoApplicableCode',
                         'source', 'Insert failed: identifier %s in repository\
-                        has source %s.' % (identifier, source))
+                        has source %s.' % (identifier, results[0].source))
 
                     try:
                         self.parent.repository.update(record)


### PR DESCRIPTION
under a different source, then harvesting isn't possible.