### PR TITLE
fix: apply repo filter when constraint is present in query

### DIFF
--- a/pycsw/core/repository.py
+++ b/pycsw/core/repository.py
@@ -254,15 +254,24 @@ class Repository(object):
         ''' Query records from underlying repository '''
 
         # run the raw query and get total
+        filter_embedded = False
         if 'where' in constraint:  # GetRecords with constraint
             LOGGER.debug('constraint detected')
+            if self.filter is not None:
+                where = '(%s) AND (%s)' % (self.filter, constraint['where'])
+                filter_embedded = True
+            else:
+                where = constraint['where']
             query = self.session.query(self.dataset).filter(
-            text(constraint['where'])).params(self._create_values(constraint['values']))
+            text(where)).params(self._create_values(constraint['values']))
         else:  # GetRecords sans constraint
             LOGGER.debug('No constraint detected')
             query = self.session.query(self.dataset)
 
-        total = self._get_repo_filter(query).count()
+        def _filtered(q):
+            return q if filter_embedded else self._get_repo_filter(q)
+
+        total = _filtered(query).count()
 
         if util.ranking_pass:  #apply spatial ranking
             #TODO: Check here for dbtype so to extract wkt from postgis native to wkt
@@ -297,7 +306,7 @@ class Repository(object):
             query = query.order_by('date_modified')
 
         # always apply limit and offset
-        return [str(total), self._get_repo_filter(query).limit(
+        return [str(total), _filtered(query).limit(
         maxrecords).offset(startposition).all()]
 
     def insert(self, record, source, insert_date):
@@ -355,8 +364,10 @@ class Repository(object):
                     if 'dbcol' not in rpu['rp']:
                         self.session.rollback()
                         raise RuntimeError('property not found for XPath %s' % rpu['rp']['name'])
-                    rows += self._get_repo_filter(self.session.query(self.dataset)).filter(
-                        text(constraint['where'])).params(self._create_values(constraint['values'])).update({
+                    update_where = '(%s) AND (%s)' % (self.filter, constraint['where']) \
+                        if self.filter is not None else constraint['where']
+                    rows += self.session.query(self.dataset).filter(
+                        text(update_where)).params(self._create_values(constraint['values'])).update({
                             getattr(self.dataset,
                             rpu['rp']['dbcol']): rpu['value'],
                             'xml': func.update_xpath(str(self.context.namespaces),
@@ -365,8 +376,8 @@ class Repository(object):
                                    str(rpu)),
                         }, synchronize_session='fetch')
                     # then update anytext tokens
-                    rows2 += self._get_repo_filter(self.session.query(self.dataset)).filter(
-                        text(constraint['where'])).params(self._create_values(constraint['values'])).update({
+                    rows2 += self.session.query(self.dataset).filter(
+                        text(update_where)).params(self._create_values(constraint['values'])).update({
                             'anytext': func.get_anytext(getattr(
                             self.dataset, self.context.md_core_model['mappings']['pycsw:XML']))
                         }, synchronize_session='fetch')
@@ -383,8 +394,10 @@ class Repository(object):
 
         try:
             self.session.begin()
-            rows = self._get_repo_filter(self.session.query(self.dataset)).filter(
-            text(constraint['where'])).params(self._create_values(constraint['values']))
+            delete_where = '(%s) AND (%s)' % (self.filter, constraint['where']) \
+                if self.filter is not None else constraint['where']
+            rows = self.session.query(self.dataset).filter(
+            text(delete_where)).params(self._create_values(constraint['values']))
 
             parentids = []
             for row in rows:  # get ids

--- a/tests/functionaltests/suites/repofilter/expected/post_GetRecords-filter.xml
+++ b/tests/functionaltests/suites/repofilter/expected/post_GetRecords-filter.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- PYCSW_VERSION -->
+<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.2" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
+  <csw:SearchStatus timestamp="PYCSW_TIMESTAMP"/>
+  <csw:SearchResults nextRecord="0" numberOfRecordsMatched="3" numberOfRecordsReturned="3" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full">
+    <csw:Record>
+    <dc:identifier>urn:uuid:88247b56-4cbc-4df9-9860-db3f8042e357</dc:identifier>
+    <dc:type>http://purl.org/dc/dcmitype/Dataset</dc:type>
+    <dc:subject scheme="http://www.digest.org/2.1">Physiography-Landforms</dc:subject>
+    <dct:spatial>FI-ES</dct:spatial>
+    <dct:abstract>Donec scelerisque pede ut nisl luctus accumsan. Quisque ultrices, lorem eget feugiat fringilla, lorem dui porttitor ante, cursus ultrices magna odio eu neque.</dct:abstract>
+</csw:Record>
+    <csw:Record>
+    <dc:identifier>urn:uuid:94bc9c83-97f6-4b40-9eb8-a8e8787a5c63</dc:identifier>
+    <dc:type>http://purl.org/dc/dcmitype/Dataset</dc:type>
+    <dc:title>Mauris sed neque</dc:title>
+    <dc:subject scheme="http://www.digest.org/2.1">Vegetation-Cropland</dc:subject>
+    <dct:abstract>Curabitur lacinia, ante non porta tempus, mi lorem feugiat odio, eget suscipit eros pede ac velit.</dct:abstract>
+    <dc:date>2006-03-26</dc:date>
+    <ows:BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326">
+      <ows:LowerCorner>47.595 -4.097</ows:LowerCorner>
+      <ows:UpperCorner>51.217 0.889</ows:UpperCorner>
+    </ows:BoundingBox>
+</csw:Record>
+    <csw:Record>
+    <dc:identifier>urn:uuid:9a669547-b69b-469f-a11f-2d875366bbdc</dc:identifier>
+    <dc:type>http://purl.org/dc/dcmitype/Dataset</dc:type>
+    <dc:title>Ñunç elementum</dc:title>
+    <dc:subject scheme="http://www.digest.org/2.1">Hydrography-Oceanographic</dc:subject>
+    <dc:date>2005-10-24</dc:date>
+    <ows:BoundingBox crs="urn:x-ogc:def:crs:EPSG:6.11:4326">
+      <ows:LowerCorner>44.792 -6.171</ows:LowerCorner>
+      <ows:UpperCorner>51.126 -2.228</ows:UpperCorner>
+    </ows:BoundingBox>
+</csw:Record>
+  </csw:SearchResults>
+</csw:GetRecordsResponse>

--- a/tests/functionaltests/suites/repofilter/post/GetRecords-filter.xml
+++ b/tests/functionaltests/suites/repofilter/post/GetRecords-filter.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ogc="http://www.opengis.net/ogc" service="CSW" version="2.0.2" resultType="results" startPosition="1" maxRecords="15" outputFormat="application/xml" outputSchema="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
+        <csw:Query typeNames="csw:Record">
+                <csw:ElementSetName>full</csw:ElementSetName>
+                <csw:Constraint version="1.1.0">
+                        <ogc:Filter>
+                                <ogc:PropertyIsLike escapeChar="\" singleChar="." wildCard="*">
+                                        <ogc:PropertyName>csw:AnyText</ogc:PropertyName>
+                                        <ogc:Literal>*</ogc:Literal>
+                                </ogc:PropertyIsLike>
+                        </ogc:Filter>
+                </csw:Constraint>
+        </csw:Query>
+</csw:GetRecords>

--- a/tests/unittests/test_repository.py
+++ b/tests/unittests/test_repository.py
@@ -29,8 +29,10 @@
 """Unit tests for pycsw.core.repository"""
 
 import os
+import shutil
 
 import pytest
+from sqlalchemy.sql import text
 
 from pycsw.core import repository
 from pycsw.core.config import StaticContext
@@ -55,6 +57,24 @@ def cite_repo_with_filter():
     )
 
 
+@pytest.fixture
+def cite_repo_with_filter_copy(tmp_path):
+    """Repository backed by a disposable copy of cite.db.
+
+    update()/delete() mutate data, so tests exercising them must not touch
+    the shared cite.db fixture used by other test suites.
+    """
+    db_copy = tmp_path / "cite.db"
+    shutil.copy(CITE_DB, db_copy)
+    context = StaticContext()
+    return repository.Repository(
+        "sqlite:///%s" % db_copy,
+        context,
+        table="records",
+        repo_filter="type = '%s'" % DATASET_TYPE,
+    )
+
+
 def test_query_with_constraint_respects_repo_filter(cite_repo_with_filter):
     """A POST constraint must not bypass the repo filter."""
     constraint = {"where": "anytext LIKE :pvalue0", "values": ["%"]}
@@ -65,6 +85,73 @@ def test_query_with_constraint_respects_repo_filter(cite_repo_with_filter):
         assert record.type == DATASET_TYPE, (
             "repo filter not applied: record %s has type %s" % (record.identifier, record.type)
         )
+
+
+def test_update_property_based_respects_repo_filter(cite_repo_with_filter_copy):
+    """A property-based update with a constraint must not bypass the repo filter."""
+    repo = cite_repo_with_filter_copy
+    constraint = {"where": "anytext LIKE :pvalue0", "values": ["%"]}
+    recprops = [{
+        "rp": {"name": "apiso:Title", "xpath": "dc:title", "dbcol": "title"},
+        "value": "updated-by-test",
+    }]
+
+    non_dataset_titles_before = {
+        record.identifier: record.title
+        for record in repo.session.query(repo.dataset).filter(repo.dataset.type != DATASET_TYPE).all()
+    }
+    assert non_dataset_titles_before, "expected non-Dataset records in cite.db to prove filter matters"
+
+    dataset_matching_constraint = repo.session.query(repo.dataset).filter(
+        text(constraint["where"])).params(repo._create_values(constraint["values"])
+    ).filter(repo.dataset.type == DATASET_TYPE).count()
+    assert dataset_matching_constraint > 0
+
+    rows = repo.update(recprops=recprops, constraint=constraint)
+
+    assert rows == dataset_matching_constraint
+    updated_dataset_records = repo.session.query(repo.dataset).filter(
+        repo.dataset.type == DATASET_TYPE, repo.dataset.title == "updated-by-test").count()
+    assert updated_dataset_records == dataset_matching_constraint
+
+    non_dataset_titles_after = {
+        record.identifier: record.title
+        for record in repo.session.query(repo.dataset).filter(repo.dataset.type != DATASET_TYPE).all()
+    }
+    assert non_dataset_titles_after == non_dataset_titles_before, (
+        "repo filter bypassed: non-Dataset record(s) were updated"
+    )
+
+
+def test_delete_respects_repo_filter(cite_repo_with_filter_copy):
+    """A delete with a constraint must not bypass the repo filter."""
+    repo = cite_repo_with_filter_copy
+    constraint = {"where": "anytext LIKE :pvalue0", "values": ["%"]}
+
+    non_dataset_ids_before = {
+        record.identifier
+        for record in repo.session.query(repo.dataset).filter(repo.dataset.type != DATASET_TYPE).all()
+    }
+    assert non_dataset_ids_before, "expected non-Dataset records in cite.db to prove filter matters"
+
+    dataset_matching_constraint = repo.session.query(repo.dataset).filter(
+        text(constraint["where"])).params(repo._create_values(constraint["values"])
+    ).filter(repo.dataset.type == DATASET_TYPE).count()
+    assert dataset_matching_constraint > 0
+
+    repo.delete(constraint)
+
+    remaining_dataset_records = repo.session.query(repo.dataset).filter(
+        repo.dataset.type == DATASET_TYPE).count()
+    assert remaining_dataset_records == 0
+
+    non_dataset_ids_after = {
+        record.identifier
+        for record in repo.session.query(repo.dataset).filter(repo.dataset.type != DATASET_TYPE).all()
+    }
+    assert non_dataset_ids_after == non_dataset_ids_before, (
+        "repo filter bypassed: non-Dataset record(s) were deleted"
+    )
 
 
 @pytest.mark.parametrize("data, input_, predicate, distance, expected", [

--- a/tests/unittests/test_repository.py
+++ b/tests/unittests/test_repository.py
@@ -28,11 +28,43 @@
 # =================================================================
 """Unit tests for pycsw.core.repository"""
 
+import os
+
 import pytest
 
 from pycsw.core import repository
+from pycsw.core.config import StaticContext
 
 pytestmark = pytest.mark.unit
+
+CITE_DB = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "functionaltests", "suites", "cite", "data", "cite.db",
+)
+DATASET_TYPE = "http://purl.org/dc/dcmitype/Dataset"
+
+
+@pytest.fixture
+def cite_repo_with_filter():
+    context = StaticContext()
+    return repository.Repository(
+        "sqlite:///%s" % CITE_DB,
+        context,
+        table="records",
+        repo_filter="type = '%s'" % DATASET_TYPE,
+    )
+
+
+def test_query_with_constraint_respects_repo_filter(cite_repo_with_filter):
+    """A POST constraint must not bypass the repo filter."""
+    constraint = {"where": "anytext LIKE :pvalue0", "values": ["%"]}
+    total, records = cite_repo_with_filter.query(constraint, maxrecords=20)
+
+    assert int(total) > 0, "expected at least one Dataset record in cite.db"
+    for record in records:
+        assert record.type == DATASET_TYPE, (
+            "repo filter not applied: record %s has type %s" % (record.identifier, record.type)
+        )
 
 
 @pytest.mark.parametrize("data, input_, predicate, distance, expected", [


### PR DESCRIPTION
- Embed repo filter directly into the WHERE clause when a user constraint is present, so filter and constraint are passed to SQLAlchemy as one combined text() expression. This fixes the POST request bug where the repo filter was not reliably applied alongside a parameterised constraint.
- Introduce filter_embedded flag in query() to skip _get_repo_filter() when the filter is already baked in, preventing double application.
- Apply the same embed pattern in update() and delete() for consistency.
- Add unit test verifying that returned records respect the repo filter when queried with a constraint.
- Add functional test for POST GetRecords with constraint + repo filter.

ING-5173

